### PR TITLE
Add gettext 0.21 and add 'threads' option

### DIFF
--- a/recipes/gettext/all/conandata.yml
+++ b/recipes/gettext/all/conandata.yml
@@ -2,6 +2,9 @@ sources:
   "0.20.1":
     sha256: "66415634c6e8c3fa8b71362879ec7575e27da43da562c798a8a2f223e6e47f5c" 
     url: "https://ftp.gnu.org/pub/gnu/gettext/gettext-0.20.1.tar.gz"
+  "0.21":
+    sha256: "c77d0da3102aec9c07f43671e60611ebff89a996ef159497ce8e59d075786b12" 
+    url: "https://ftp.gnu.org/pub/gnu/gettext/gettext-0.21.tar.gz"
 patches:
   "0.20.1":
     - patch_file: "patches/0001-build-Fix-build-errors-with-MSVC.patch"
@@ -9,4 +12,7 @@ patches:
     - patch_file: "patches/0002-memmove-is-intrinsic-function-on-MSVC.patch"
       base_path: "source_subfolder"
     - patch_file: "patches/0003-Reported-by-Gabor-Z.-Papp-gzp-papp.hu.patch"
+      base_path: "source_subfolder"
+  "0.21":
+    - patch_file: "patches/0002-memmove-is-intrinsic-function-on-MSVC.patch"
       base_path: "source_subfolder"

--- a/recipes/gettext/all/conanfile.py
+++ b/recipes/gettext/all/conanfile.py
@@ -14,8 +14,8 @@ class GetTextConan(ConanFile):
     license = "GPL-3.0-or-later"
     settings = "os", "arch", "compiler", "build_type"
     exports_sources = ["patches/*.patch"]
-    options = {"shared": [True, False], "fPIC": [True, False]}
-    default_options = {"shared": False, "fPIC": True}
+    options = {"shared": [True, False], "fPIC": [True, False], "threads": ["posix", "solaris", "pth", "windows", "disabled", "auto"]}
+    default_options = {"shared": False, "fPIC": True, "threads": "auto" }
     requires = ("libiconv/1.16")
 
     _autotools = None
@@ -47,6 +47,8 @@ class GetTextConan(ConanFile):
         if self.settings.compiler == "Visual Studio" and \
            tools.Version(self.settings.compiler.version) == "15":
             raise ConanInvalidConfiguration("Gettext does not support Visual Studio 15.")
+        if(self.options.threads == "auto"):
+            self.options.threads = { "Solaris": "solaris", "Windows": "windows" }.get(str(self.settings.os), "posix")
 
     def build_requirements(self):
         if tools.os_info.is_windows:
@@ -75,6 +77,7 @@ class GetTextConan(ConanFile):
                 "--disable-csharp",
                 "--disable-libasprintf",
                 "--disable-curses",
+                "--disable-threads" if self.options.threads == "disabled" else ("--enable-threads=" + str(self.options.threads)),
                 "--with-libiconv-prefix=%s" % libiconv_prefix]
         build = None
         host = None


### PR DESCRIPTION
Add the gettext 0.21 version which fixes cross-compiling to windows, and provide a `threads` option that is passed to `./configure` which allows setting the used thread API. This can avoid dependencies to pthread wrappers on windows.